### PR TITLE
Scan Constants, Byte Suffix and Small Fixes

### DIFF
--- a/ExePatch.cs
+++ b/ExePatch.cs
@@ -400,7 +400,7 @@ namespace p4gpc.inaba
                             mLogger.WriteLine($"[Inaba Exe Patcher] Unable to parse {value} as an int, double, float or string not creating search pattern");
                             continue;
                         }
-                        string stringValue = stringValueMatch.Groups[1].Value;
+                        string stringValue = Regex.Unescape(stringValueMatch.Groups[1].Value);
                         var bytes = Encoding.ASCII.GetBytes(stringValue);
                         pattern = BitConverter.ToString(bytes).Replace("-", " ");
                     }
@@ -604,7 +604,7 @@ namespace p4gpc.inaba
                     mLogger.WriteLine($"[Inaba Exe Patcher] Unable to parse {value} as an int, double, float or string not writing a value for {name}");
                     return;
                 }
-                string stringValue = stringValueMatch.Groups[1].Value;
+                string stringValue = Regex.Unescape(stringValueMatch.Groups[1].Value);
                 var stringBytes = Encoding.ASCII.GetBytes(stringValue);
                 if (stringBytes.Length < stringLength)
                 {

--- a/ExePatch.cs
+++ b/ExePatch.cs
@@ -150,7 +150,20 @@ namespace p4gpc.inaba
 
         private void SinglePatchEx(string filePath)
         {
-            List<ExPatch> patches = ParseExPatch(filePath);
+            (List<ExPatch> patches, Dictionary<string, string> constants) = ParseExPatch(filePath);
+            foreach(var constant in constants)
+            {
+                mStartupScanner.AddMainModuleScan(constant.Value, result =>
+                {
+                    if(!result.Found)
+                    {
+                        mLogger.WriteLine($"[Inaba Exe Patcher] Couldn't find address for const {constant.Value}, it will not be replaced", Color.Red);
+                        return;
+                    }
+
+                    FillInConstant(patches, constant.Key, (result.Offset + (int)mBaseAddr).ToString());
+                });
+            }
             foreach (var patch in patches)
             {
                 mStartupScanner.AddMainModuleScan(patch.Pattern, (result) =>
@@ -230,8 +243,8 @@ namespace p4gpc.inaba
         /// Parses all of the patches from an expatch file
         /// </summary>
         /// <param name="filePath">The path to the expatch file</param>
-        /// <returns>A list of all of the found patches in the file</returns>
-        private List<ExPatch> ParseExPatch(string filePath)
+        /// <returns>A tuple containing a list of all of the found patches in the file and a dictionary of all constants that need to be scanned for</returns>
+        private (List<ExPatch>, Dictionary<string, string>) ParseExPatch(string filePath)
         {
             List<ExPatch> patches = new List<ExPatch>();
             bool startPatch = false;
@@ -244,6 +257,7 @@ namespace p4gpc.inaba
             bool padNull = true;
             Dictionary<string, IntPtr> variables = new();
             Dictionary<string, string> constants = new();
+            Dictionary<string, string> scanConstants = new();
 
             foreach (var rawLine in File.ReadLines(filePath))
             {
@@ -319,12 +333,21 @@ namespace p4gpc.inaba
                 if (constantMatch.Success)
                 {
                     string name = constantMatch.Groups[1].Value;
-                    if (constants.ContainsKey(name))
+                    if (constants.ContainsKey(name) || scanConstants.ContainsKey(name))
                     {
                         mLogger.WriteLine($"[Inaba Exe Patcher] Constant {name} in {Path.GetFileName(filePath)} already exists, ignoring duplicate declaration of it");
                         continue;
                     }
-                    constants.Add(name, constantMatch.Groups[2].Value);
+                    string constValue = constantMatch.Groups[2].Value;
+                    var scanMatch = Regex.Match(constValue, @"scan\((.*)\)", RegexOptions.IgnoreCase);
+                    if (scanMatch.Success)
+                    {
+                        scanConstants.Add(name, scanMatch.Groups[1].Value);
+                    }
+                    else
+                    {
+                        constants.Add(name, constantMatch.Groups[2].Value);
+                    }
                     continue;
                 }
 
@@ -431,7 +454,7 @@ namespace p4gpc.inaba
             if (startReplacement || startPatch)
                 SaveCurrentPatch(currentPatch, patches, patchName, ref pattern, ref order, ref offset, ref padNull, startReplacement);
             FillInVariables(patches, variables, constants);
-            return patches;
+            return (patches, scanConstants);
         }
 
         private void SaveCurrentPatch(List<string> currentPatch, List<ExPatch> patches, string patchName, ref string pattern, ref string order, ref int offset, ref bool padNull, bool isReplacement)
@@ -447,6 +470,23 @@ namespace p4gpc.inaba
             order = "";
             offset = 0;
             padNull = true;
+        }
+
+        /// <summary>
+        /// Replaces any constant definitions with their value
+        /// </summary>
+        /// <param name="patches">A list patches to replace the constant in</param>
+        /// <param name="name">The name of the constant</param>
+        /// <param name="value">The value of the constant</param>
+        private void FillInConstant(List<ExPatch> patches, string name, string value)
+        {
+            foreach(var patch in patches)
+            {
+                for(int i = 0; i < patch.Function.Length; i++)
+                {
+                    patch.Function[i] = patch.Function[i].Replace($"{{{name}}}", value);
+                }
+            }
         }
 
         /// <summary>

--- a/ExePatch.cs
+++ b/ExePatch.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using Reloaded.Mod.Interfaces;
 using System.IO;
@@ -456,7 +456,7 @@ namespace p4gpc.inaba
         /// <param name="variables">A Dictionary where the key is the variable name and the value is the variable address</param>
         private void FillInVariables(List<ExPatch> patches, Dictionary<string, IntPtr> variables, Dictionary<string, string> constants)
         {
-            if (variables.Count == 0)
+            if (variables.Count == 0 && constants.Count == 0)
                 return;
             foreach (var patch in patches)
                 for (int i = 0; i < patch.Function.Length; i++)

--- a/ExePatch.cs
+++ b/ExePatch.cs
@@ -560,6 +560,37 @@ namespace p4gpc.inaba
                 }
                 catch { }
             }
+            match = Regex.Match(value, @"^([+-])?(0x|0b)?([0-9A-Fa-f]+)([su])b$");
+            if (match.Success)
+            {
+                int offsetBase = 10;
+                if (match.Groups[2].Success)
+                {
+                    if (match.Groups[2].Value == "0b")
+                        offsetBase = 2;
+                    else if (match.Groups[2].Value == "0x")
+                        offsetBase = 16;
+                }
+                try
+                {
+                    if (match.Groups[4].Value == "s")
+                    {
+                        sbyte byteValue = Convert.ToSByte(match.Groups[3].Value, offsetBase);
+                        if (match.Groups[1].Value == "-")
+                            byteValue *= -1;
+                        mem.SafeWrite(address, byteValue);
+                        mLogger.WriteLine($"[Inaba Exe Patcher] Wrote sbyte {byteValue} as value of {name} at 0x{address:X}");
+                    }
+                    else
+                    {
+                        byte byteValue = Convert.ToByte(match.Groups[3].Value, offsetBase);
+                        mem.SafeWrite(address, byteValue);
+                        mLogger.WriteLine($"[Inaba Exe Patcher] Wrote ubyte {byteValue} as value of {name} at 0x{address:X}");
+                    }
+                    return;
+                }
+                catch { }
+            }
             match = Regex.Match(value, @"^([+-])?(0x|0b)?([0-9A-Fa-f]+)(u)?l$");
             if (match.Success)
             {

--- a/ModConfig.json
+++ b/ModConfig.json
@@ -2,7 +2,7 @@
   "ModId": "p4gpc.inaba",
   "ModName": "Inaba Exe Patcher",
   "ModAuthor": "Tekka",
-  "ModVersion": "1.3.1",
+  "ModVersion": "2.0.0",
   "ModDescription": "Simple patcher to modify contents in P4G.exe at startup",
   "ModDll": "p4gpc.inaba.dll",
   "ModIcon": "Preview.png",

--- a/Program.cs
+++ b/Program.cs
@@ -7,6 +7,7 @@ using p4gpc.inaba.Configuration.Implementation;
 using System.IO;
 using Reloaded.Memory.SigScan.ReloadedII.Interfaces;
 using System.Diagnostics;
+using System.Drawing;
 
 namespace p4gpc.inaba
 {
@@ -50,8 +51,16 @@ namespace p4gpc.inaba
 
             _modLoader = (IModLoader)loader;
             _logger = (ILogger)_modLoader.GetLogger();
-            _modLoader.GetController<IReloadedHooks>().TryGetTarget(out _hooks);
-            _modLoader.GetController<IStartupScanner>().TryGetTarget(out var startupScanner);
+            if(!_modLoader.GetController<IReloadedHooks>().TryGetTarget(out _hooks))
+            {
+                _logger.WriteLine($"[Inaba Exe Patcher] Unable to get controller for Reloaded Hooks, aborting initialisation", Color.Red);
+                return;
+            }
+            if (!_modLoader.GetController<IStartupScanner>().TryGetTarget(out var startupScanner))
+            {
+                _logger.WriteLine($"[Inaba Exe Patcher] Unable to get controller for Reloaded SigScan Library, aborting initialisation", Color.Red);
+                return;
+            }
 
             // Your config file is in Config.json.
             // Need a different name, format or more configurations? Modify the `Configurator`.


### PR DESCRIPTION
Ex Patch Additions:
- Scan constants that allow you to signature scan for an address and use that address throughout patches like normal constants and variables
- Support for signed and unsigned bytes denoted by a number suffixed with `sb` or `ub` respectively (such as `255ub`)

(To match these additions the [Function Hooks](https://github.com/AnimatedSwine37/Inaba-Exe-Patcher/wiki/Function-Hooks), [Replacements](https://github.com/AnimatedSwine37/Inaba-Exe-Patcher/wiki/Replacements) and [Value Types](https://github.com/AnimatedSwine37/Inaba-Exe-Patcher/wiki/Value-Types) wiki pages have been updated on my fork, so please apply this to the main version of the wiki)

Fixes:
- Fixed constants not being filled in if there were no variables defined in an expatch
- Fixed the default execution order not actually being `only` even though it was listed as that
- Fixed special characters in strings (such as `\n` and `\t`) not being unescaped when using them
- Added error handling if the Reloaded hooks or SigScan controllers can't be gotten